### PR TITLE
Alter the order of some menu items

### DIFF
--- a/incidentalmusic/index.md
+++ b/incidentalmusic/index.md
@@ -2,7 +2,7 @@
 layout: section
 category: incidentalmusic
 image: /public/images/recording-evening-work.jpg
-weight: 1
+weight: 2
 title: Incidental Music
 ---
 

--- a/musicshakers/index.md
+++ b/musicshakers/index.md
@@ -1,7 +1,7 @@
 ---
 layout: section
 category: musicshakers
-weight: 1
+weight: 5
 title: Music Shakers
 ---
 <aside class="pull-right"><a href="http://www.musicshakers.com/" title="Music Shakers site"><img src="http://www.musicshakers.com/musicshakerslogo.jpg" title="Music Shakers logo"></a></aside>


### PR DESCRIPTION
This changes the order of the sidebar menu a little, so Music Shakers isn't the first item after About, and so your publications and piano music come first.

<img width="283" alt="Screenshot 2020-08-18 at 12 11 05" src="https://user-images.githubusercontent.com/518081/90506313-ee98a780-e14b-11ea-9081-4009631acf2d.png">
