### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 11ty
 
+permissions:
+  contents: write
+
 env:
   ELEVENTY_ENV: production
 


### PR DESCRIPTION
Potential fix for [https://github.com/Bakertunes/www.bakertunes.com/security/code-scanning/4](https://github.com/Bakertunes/www.bakertunes.com/security/code-scanning/4)

Add an explicit `permissions` block to `.github/workflows/build.yml` so the token is least-privileged by default, while granting only the write scope needed for deploying to `11ty-site`.

Best single fix without changing functionality:
- At workflow root (recommended for clarity), add:
  - `contents: write` (required to push deployment commits to the target branch)
- Keep all existing steps unchanged.

Where to change:
- File: `.github/workflows/build.yml`
- Insert the `permissions` block between the `on:` trigger section and `env:` (or anywhere at workflow root level before `jobs:`).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
